### PR TITLE
Fix to Bernoulli Partition Test

### DIFF
--- a/test/glm/partition_functions/bernoulli_partition.jl
+++ b/test/glm/partition_functions/bernoulli_partition.jl
@@ -189,7 +189,7 @@ second_der_lp(η) = 1/(1+exp(-η))*(1/(1+exp(η)))
                     atol=sqrt(eps(type)*num_param)
                 )
                 @test isapprox(norm(hessian) - norm(hessian[params, params]), 
-                    0, atol=eps(type))
+                    0, atol=eps(type)*num_param)
             end
         end
     end


### PR DESCRIPTION
The following error occurs during tests.

```
Bernoulli Log Partition Function: Test Failed at /home/runner/work/OptimizationProblems.jl/OptimizationProblems.jl/test/glm/partition_functions/bernoulli_partition.jl:191
  Expression: isapprox(norm(hessian) - norm(hessian[params, params]), 0, atol = eps(type))
   Evaluated: isapprox(4.440892098500626e-16, 0; atol = 2.220446049250313e-16)
```

This PR reduces the tolerance required for the difference by changing `atol = eps(type)` to `atol = eps(type) * num_param`.